### PR TITLE
getRandom()関数で文字の数字が与えられた時の挙動を修正、その他コメント・バグ修正

### DIFF
--- a/mathRandom.js
+++ b/mathRandom.js
@@ -1,14 +1,22 @@
+/**
+ * 引数の範囲内でランダムで出力した数値を返す
+ * @param {number} min
+ * @param {number} max
+ * @return {number|undefined}
+ */
 module.exports = function getRandom( min = 0 , max = 100 ) {
   console.log(min,max);
-  
-  if(isNaN(min,max)==true){
+
+  if(isNaN(min) || isNaN(max)){
     console.log('引数エラー：数値以外が入力されています');
+    return
   }
   else if(min>max){
     console.log('引数エラー：数値を入れ替えて入力してください');
+    return
   }
   else{
-  var random = Math.floor( Math.random() * (max + 1 - min) ) + min;
+  const random = Math.floor( Math.random() * (Number(max) + 1 - Number(min)) ) + Number(min);
   return random;
   }
 }


### PR DESCRIPTION
## 原因
### 文字としての数値(string型)を数値型(number型)に変換していなかった。

文字(string)として渡られた数字(数字の文字列)を、数値(number)として変換していなかったため、
Math.random()やMath.flooer()関数が、渡された値を文字のまま数値に変換してランダム値を生成していた。

## 対策
Number(somthing)関数で文字を数値に変換してからランダム値を生成する。